### PR TITLE
Fix script entrypoints to include len(sys.argv)

### DIFF
--- a/fetch/scripts/now.py
+++ b/fetch/scripts/now.py
@@ -11,7 +11,7 @@ def main():
     """
     Run once for the given rules.
     """
-    return_usage = any((sys.argv < 2, '-h' in sys.argv, '--help' in sys.argv))
+    return_usage = any((len(sys.argv) < 2, '-h' in sys.argv, '--help' in sys.argv))
 
     if return_usage:
         sys.stderr.writelines([

--- a/fetch/scripts/service.py
+++ b/fetch/scripts/service.py
@@ -12,7 +12,7 @@ def main():
     """
     Run
     """
-    return_usage = any((sys.argv < 2, '-h' in sys.argv, '--help' in sys.argv))
+    return_usage = any((len(sys.argv) < 2, '-h' in sys.argv, '--help' in sys.argv))
 
     if return_usage:
         sys.stderr.writelines([


### PR DESCRIPTION
I missed the length parameter for the determination to show helper text