### PR TITLE
Add native-requests session authorizatoin for USGS's updated requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,16 @@
 exclude: tests/integration/data
 
 repos:
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/pycqa/flake8
       # flake8 version should match .travis.yml
-      rev: 3.9.2
+      rev: 6.0.0
       hooks:
           - id: flake8
             additional_dependencies:
                   - flake8-debugger # Don't commit debugger calls
                   - flake8-logging-format # Use log arguments, not string format
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
+      rev: v4.4.0
       hooks:
         - id: check-added-large-files # We don't want huge files. (Cut down test data!)
           args: ['--maxkb=3000']

--- a/fetch/http.py
+++ b/fetch/http.py
@@ -126,6 +126,8 @@ class HttpAuthAction(SimpleObject):
 
     def __repr__(self):
         fields = self.__dict__
+
+        # We'd rather not log the password.
         if self.username_password:
             fields = fields.copy()
             fields['username_password'] = (self.username_password[0], '<**redacted**>')

--- a/fetch/http.py
+++ b/fetch/http.py
@@ -124,6 +124,14 @@ class HttpAuthAction(SimpleObject):
 
         return closing(res)
 
+    def __repr__(self):
+        fields = self.__dict__
+        if self.username_password:
+            fields = fields.copy()
+            fields['username_password'] = (self.username_password[0], '<**redacted**>')
+
+        return '%s(%r)' % (self.__class__.__name__, fields)
+
 
 class _HttpBaseSource(DataSource):
     """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='fetch',
           'feedparser',
           'lxml',
           'pathlib;python_version<"3.4"',
-          'pyyaml<5.1',
+          'pyyaml',
           'requests>=2.21.0',
           'future;python_version<"3"',
       ] + (


### PR DESCRIPTION
Our previous fix used `urllib`, but the mix of `requests` and `urllib` in one file made certain deployment config harder in NCI.

(such as setting global IPv6 preferences, which are different in each library)


Also includes
- Don't log passwords from the newer HTTPAuth module.
- Bump of support libraries which were old enough to break install.